### PR TITLE
added neepmeat projector to whitelist

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ loader_version=0.15.11
 
 # Mod Properties
 # upstream+fork
-mod_version=1.10.2+1.0.2
+mod_version=1.10.2+1.0.3
 maven_group=website.eccentric
 archives_base_name=eccentrictome
 

--- a/src/main/java/website/eccentric/tome/Configuration.java
+++ b/src/main/java/website/eccentric/tome/Configuration.java
@@ -55,7 +55,8 @@ public class Configuration {
                                 "tconstruct:mighty_smelting",
                                 "tconstruct:puny_smelting",
                                 "tconstruct:tinkers_gadgetry",
-                                "theoneprobe:probenote"),
+                                "theoneprobe:probenote",
+                                "neepmeat:projector"),
                         Validator::isStringResource);
 
         NAMES = BUILDER


### PR DESCRIPTION
For some reason the config file wouldn't let me edit it directly (it just generated .bak copies of the config with the changes), so I just hard-coded Neepmeat's guide projector into the config generator. Also tiny version bump.